### PR TITLE
fix: replace fetch with axios for country code retrieval in RegisterPage

### DIFF
--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -21,6 +21,7 @@ import Image from "next/image";
 import peon from "@/app/ui/icons/peon_logo_invert.svg";
 import Board from "@/app/ui/icons/board.svg";
 import Link from "next/link";
+import axios from "axios";
 
 export default function RegisterPage() {
   const {
@@ -63,9 +64,8 @@ export default function RegisterPage() {
   useEffect(() => {
     const fetchCountry = async () => {
       try {
-        const response = await fetch("https://ipapi.co/json/");
-        const data = await response.json();
-        setCountryCode(data.country_code);
+        const response = await axios.get("https://ipapi.co/json/");
+        setCountryCode(response.data.country_code);
       } catch (error) {
         console.error("Error fetching country data:", error);
       }


### PR DESCRIPTION
This pull request includes changes to the `app/(auth)/register/page.tsx` file to improve the handling of HTTP requests by switching from the Fetch API to Axios.

Improvements to HTTP requests:

* [`app/(auth)/register/page.tsx`](diffhunk://#diff-bdc4811d55ad8e0c687a98535b7be088f01df1f5728d8181733a14787e1dc04aR24): Added an import statement for Axios.
* [`app/(auth)/register/page.tsx`](diffhunk://#diff-bdc4811d55ad8e0c687a98535b7be088f01df1f5728d8181733a14787e1dc04aL66-R68): Modified the `fetchCountry` function to use Axios for fetching country data instead of the Fetch API.