### PR TITLE
fix: remove console log and adjust width in GameResume; add click out…

### DIFF
--- a/app/game-history/_components/game-resume.tsx
+++ b/app/game-history/_components/game-resume.tsx
@@ -56,7 +56,6 @@ export default function GameResume({ options }: GameResumeProps) {
         }
         const response = await axios.get(url);
         setGames(response.data.data);
-        console.log(response.data.data);
       } catch (error) {
         console.error("Error fetching friends:", error);
       }
@@ -86,7 +85,7 @@ export default function GameResume({ options }: GameResumeProps) {
   };
 
   return (
-    <div className="w-[334px] space-y-lg">
+    <div className="w-full space-y-lg">
       {games.data && games.data.length > 0 ? (
         <div className="space-y-lg">
           {games.data.map((game, index) => (

--- a/app/ui/components/DropDown/DropDownButton.tsx
+++ b/app/ui/components/DropDown/DropDownButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import StyledButton from "../typography/StyledButton";
 import Image from "next/image";
 
@@ -40,6 +40,7 @@ export default function DropdownButton({
   const [selectedLabel, setSelectedLabel] = useState(dropDown.title);
 
   const { setGameOptions } = useGameOptions();
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
   // Función para alternar la visibilidad del dropdown
   const toggleDropdown = () => {
@@ -54,9 +55,31 @@ export default function DropdownButton({
     setIsDropdownVisible(false);
   }
 
+  // Cerrar el dropdown al hacer clic fuera
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsDropdownVisible(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
   return (
-    <div id="dropdownButton">
-      <div className="flex justify-center">
+    <div
+      id="dropdown-container"
+      className="relative"
+      ref={dropdownRef} // Referencia al contenedor del dropdown
+    >
+      <div className="flex justify-center" id="dropdownButton">
         <StyledButton
           style={dropDown.dropStyles}
           extraClasses="w-full flex justify-between items-center bg-dark-2"
@@ -82,7 +105,9 @@ export default function DropdownButton({
       </div>
 
       <div
-        className={`absolute h-auto w-[334px] select-none rounded-base border-x-2 border-b-2 border-primary bg-dark-2 ${isDropdownVisible ? "" : "hidden"}`}
+        className={`absolute z-10 h-auto w-full select-none rounded-base border-x-2 border-b-2 border-primary bg-dark-2 ${
+          isDropdownVisible ? "" : "hidden"
+        }`}
         id="dropdown"
       >
         {options && options.length > 0 ? (


### PR DESCRIPTION
This pull request includes several changes to the `GameResume` and `DropDownButton` components to improve functionality and user experience. The most important changes include removing a debug statement, adjusting layout styles, and adding functionality to close the dropdown when clicking outside.

Improvements to `GameResume` component:

* Removed the `console.log` statement used for debugging purposes to clean up the code. (`app/game-history/_components/game-resume.tsx`)
* Modified the layout style to make the component responsive by changing the width class from a fixed value to `w-full`. (`app/game-history/_components/game-resume.tsx`)

Enhancements to `DropDownButton` component:

* Imported `useEffect` and `useRef` hooks to manage the dropdown's visibility state. (`app/ui/components/DropDown/DropDownButton.tsx`)
* Added a `useRef` hook to reference the dropdown container. (`app/ui/components/DropDown/DropDownButton.tsx`)
* Implemented a `useEffect` hook to close the dropdown when clicking outside of it. (`app/ui/components/DropDown/DropDownButton.tsx`)
* Adjusted the dropdown's styling to ensure it is properly positioned and visible when active. (`app/ui/components/DropDown/DropDownButton.tsx`)